### PR TITLE
Refactor for Plugin Selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,27 @@
 # Changelog
 
-## Unreleased
+## v0.0.1
+
+### 🚀 Added
+
+* Clicking AirPlane Mode now opens a menu where you can choose between
+  enable/disabe and editing which plugins are included as disabled
+
+* Generate a default file of plugins on first use - this is only generated if 
+there is no list file
+
+* Added menu of all installed plugins on your device with the option of adding
+  any of them to the disabe list when AirPlane mode is enabled
+
+* Added paperplane icons to indicate status
+
+### 🩹 Fixes
+
+* 
+
+## v0.0.1-alpha (2025.05.06)
+
+* Initial testing release
 
 ### 🚀 Added
 
@@ -9,8 +30,3 @@
 ### 🩹 Fixes
 
 * Existential nihilism
-
-## v0.0.1-alpha (2025.05.06)
-
-* Initial testing release
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ there is no list file
 
 * Added paperplane icons to indicate status
 
+* Documentation updated!
+
 ### 🩹 Fixes
 
 * cleaned up all of the commented code and debug statements :-)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ there is no list file
 
 ### 🩹 Fixes
 
-* 
+* cleaned up all of the commented code and debug statements :-)
 
 ## v0.0.1-alpha (2025.05.06)
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ For this iteration, I changed how we manage the plugins to disable/enable when s
 1. Copy the `airplanemode.koplugin` directory to `.adds/koreader/plugins/` or unpack a release file in your plugins directory
 1. Disconnect USB
 
+## Known bugs
+
+The only known bug is I've had a report from Kindle users that the module deactivating isn't working. I can duplicate this behavior in the koreader emulator and will tackle it next, but wanted to get this release out first since it is a significant change in functionality as far as plugin management.
+
 ## Usage
 
 ### Enabling

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 This plugin is intended to give you the ability to quickly put your koreader into AirPlane mode, disabling any netwoked plugins, as well as your wireless device. It will also switch your wireless device to force prompts while in AirPlane. Exiting AirPlane mode will re-enable your previous plugins and re-set your WiFi settings to pre-AirPlane mode settings.
 
---
+---
 
 ## IF YOU TESTED THE ALPHA
 
 For this iteration, I changed how we manage the plugins to disable/enable when switching modes. If your device is currently in `AirPlane Mode`, please exit `AirPlane Mode` before upgrading.
 
---
+---
 
 ## Installation
 
@@ -18,15 +18,55 @@ For this iteration, I changed how we manage the plugins to disable/enable when s
 
 ## Usage
 
-In the Nework tab, enter the menu for `AirPlane Mode`. You can choose to enable/disable AirPlane Mode from here.
+### Enabling
 
-<!-- Update Screenshot -->
-![Screenshot of the Network tab with AirPlane Mode installed](<https://raw.githubusercontent.com/kodermike/kodermike.github.io/refs/heads/master/images/airplane_mode_menu.png>)
+In the Nework tab, tap or click the menu for `AirPlane Mode`. 
 
-When not enabled, you can also go through the list of your installed plugins and choose which ones to disable when in `AirPlane Mode`.
+![Screenshot of the Network tab with AirPlane Mode installed](<https://raw.githubusercontent.com/kodermike/kodermike.github.io/refs/heads/master/images/airplane_network_menu.png>)
 
-<!-- ADD SCREENSHOT -->
+The `AirPlane Mode` menu is very simple - toggle `AirPlane Mode` and control which plugins will be disabled while it's running.
+
+![Screenshot of the AirPlane Mode menu when disabled](<https://raw.githubusercontent.com/kodermike/kodermike.github.io/refs/heads/master/images/airplane_disabled.png>)
+
+Tapping on `Enable` will start `AirPlane Mode` and prompt to restart your device. This is necessary for the changes we've made to running plugins to take effect.
+
+![Screenshot of the AirPlane Mode menu when disabled](<https://raw.githubusercontent.com/kodermike/kodermike.github.io/refs/heads/master/images/airplane_starting.png>)
+
+### Disabliing
+
+Turning AirPlane Mode off is simple. Return to the `AirPlane Menu` in `Network` and tap the Disable the button. We will need to restart again since we are re-enabling plugins that were disabled while offline.
+
+![Screenshot of the AirPlane Mode menu when disabled](<https://raw.githubusercontent.com/kodermike/kodermike.github.io/refs/heads/master/images/airplane_stopping.png>)
+
+## Plugin Management while in AirPlane Mode
+
+Selecting `AirPlane Mode Plugin Manager` will let you chose which plugins will be disabled when in `AirPort Mode`.
+
+![Screenshot of the AirPlane Mode menu when disabled](<https://raw.githubusercontent.com/kodermike/kodermike.github.io/refs/heads/master/images/airplane_disabled.png>)
+
+By default, AirPlane Mode will disable the plugins 
+* `Calibre`
+* `HTTP Inspector`
+* `News Downloader`
+* `OPDS`
+* `Progress Sync`
+* `SSH`
+* `Time Sync`
+* `Wallabag`
+
+These are all plugins that come pre-installed and enabled in most KOReader bundles. In the `AirPlane Mode Plugin Manager` you will have the option to choose other plugins, as well as let some of the default disables be re-enabled. When in this menu, you will not be able to disable plugins if they are already disabled in your reader.
+
+![Screenshot of the AirPlane Mode menu when disabled](<https://raw.githubusercontent.com/kodermike/kodermike.github.io/refs/heads/master/images/airplane_module_select.png>)
+
+If you attempt to change which modules `AirPlane Mode` has diabled in the Module menu while running `AirPlane Mode`, you will receive an error message.
+
+![Screenshot of the AirPlane Mode Plugin Manager if AirPlane is already running](<https://raw.githubusercontent.com/kodermike/kodermike.github.io/refs/heads/master/images/airplane_running_no_mod.png>)
+
+When you exit `AirPlane Mode`, any plugins that were not disabled before you started will be reactivated by the restart.
+
 
 ## Find a bug?
 
 Please open an issue in GitHub so we can start looking at what isn't working right.
+
+###### Updated 2025.05.21

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 This plugin is intended to give you the ability to quickly put your koreader into AirPlane mode, disabling any netwoked plugins, as well as your wireless device. It will also switch your wireless device to force prompts while in AirPlane. Exiting AirPlane mode will re-enable your previous plugins and re-set your WiFi settings to pre-AirPlane mode settings.
 
+--
+
+## IF YOU TESTED THE ALPHA
+
+For this iteration, I changed how we manage the plugins to disable/enable when switching modes. If your device is currently in `AirPlane Mode`, please exit `AirPlane Mode` before upgrading.
+
+--
+
 ## Installation
 
 1. Connect your device to USB
@@ -10,18 +18,15 @@ This plugin is intended to give you the ability to quickly put your koreader int
 
 ## Usage
 
-In the Nework tab, check the checkbox for `AirPlane Mode`. Koreader will restart when enabling and disabling AirPlane mode.
+In the Nework tab, enter the menu for `AirPlane Mode`. You can choose to enable/disable AirPlane Mode from here.
 
+<!-- Update Screenshot -->
 ![Screenshot of the Network tab with AirPlane Mode installed](<https://raw.githubusercontent.com/kodermike/kodermike.github.io/refs/heads/master/images/airplane_mode_menu.png>)
 
-## Missing plugin or bug?
+When not enabled, you can also go through the list of your installed plugins and choose which ones to disable when in `AirPlane Mode`.
 
-If I missed a network using plugin, just open an issue and I'll add it! And of course, if you find a bug, let me know.
+<!-- ADD SCREENSHOT -->
 
-## Known Caveat
+## Find a bug?
 
-Currently, AirPlane mode attemtpts to re-enable yoru WiFi device when exiting. I may change this behavior in the future and let your previous setting handle whether to reconnect.
-
-## TODO
-
-* Add the ability to choose what is disabled with airplane mode
+Please open an issue in GitHub so we can start looking at what isn't working right.

--- a/main.lua
+++ b/main.lua
@@ -52,7 +52,7 @@ function AirPlaneMode:initSettingsFile()
     else
         local airplane_plugins = LuaSettings:open(self.airplane_plugins_file)
         local default_disable = {}
-        local default_disable_list = {"goodreads","newsdownloader","wallabag","calibre","kosync","opds","SSH","timesync","httpinspector"}
+        local default_disable_list = {"newsdownloader","wallabag","calibre","kosync","opds","SSH","timesync","httpinspector"}
         for __, plugin in ipairs(default_disable_list) do
             default_disable[plugin] = true
         end

--- a/main.lua
+++ b/main.lua
@@ -306,36 +306,11 @@ local function airplanemode_status()
     end
     ---------
     if settings_bk_exists == true and airplanemode_active == true then
+        logger.dbg("Airplane - returning airplanemode_status as true")
         return true
     elseif airplanemode_active == false then
+        logger.dbg("Airplane - returning airplanemode_status as false")
         return false
-    end
-end
-
-function AirPlaneMode:onMenuHold()
-    local edit_dialog
-    local title = _("Edit Plugins To Decactivate")
-    if airplanemode_status() == true then
-        edit_dialog = {
-            title = title,
-            callback = function()
-                UIManager:show(InfoMessage:new{
-                    text = _("AirPlane Mode can't be configured while running"),
-                })
-            end,
-        }
-        UIManager:show(edit_dialog)
-    else -- TODO replace with call to the menu page for plugins
-
-        edit_dialog = {
-            title = title,
-            callback = function()
-                UIManager:show(InfoMessage:new{
-                    text = _("For now nothing can be configured in AirPlane Mode"),
-                })
-            end,
-        }
-        UIManager:show(edit_dialog)
     end
 end
 
@@ -352,12 +327,6 @@ local function getMenuTable(plugin)
     t.fullname = string.format("%s", plugin.fullname or plugin.name)
     t.description = string.format("%s", plugin.description)
     return t
-end
-
-local function tablelength(T)
-  local count = 0
-  for _ in pairs(T) do count = count + 1 end
-  return count
 end
 
 function AirPlaneMode:getSubMenuItems()
@@ -470,6 +439,7 @@ function AirPlaneMode:addToMainMenu(menu_items)
         sorting_hint = "network",
         checked_func = function() return airplanemode_status() end,
         callback = function()
+        --checked_func = function()
             if Device:isAndroid() then
                 UIManager:show(ConfirmBox:new{
                     dismissable = false,
@@ -480,7 +450,7 @@ function AirPlaneMode:addToMainMenu(menu_items)
                     end,
                 })
             else
-                if airplanemode_status() then
+                if airplanemode_status() == true then
                     --airplanemode = true
                     self:turnoff()
                 else


### PR DESCRIPTION
This update adds the ability to select which plugins are disabled while in AirPlane. A default set is setup, but you can add (or remove) plugins from running while in AirPlane. This release also rewrite how we reactivate from AirPlane, attempting to be more adaptable even if you change settings while in AirPlane. So long as the changes are significant and module specific, it should recover gracefully.

# Previous Users

Prior users of AirPlane mode will need to be sure AirPlane is not running when upgrading. Because of changes in how the plugin works, I cannot guarantee a clean exit if you change versions while in AirPlane. If this happens, open a ticket, it should be pretty trivial to fix but will require you to be willing to work directly on your device.

## Kindle users

I have verified there is a problem with kindle devices and plugins via the emulator. I've gone ahead and [open the first issue](https://github.com/kodermike/airplanemode.koplugin/issues/1) to address this. Everyone is welcome to comment and follow the ticket, I would love to share potential fixes, otherwise I will trust the emulator is a fair comparison until I can jailbreak an old kindle.

Also, thanks! I will be releasing this 0.0.1, but expect 0.0.2 to be out as soon as I can address the kindle issue. (this is the worst pull request description ever)