### PR TITLE
Networking and ui Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.0.3  (2025.05.??) - UNRELEASED CURRENTLY
+## v0.0.3  (2025.05.26) - UNRELEASED CURRENTLY
 
 ### TODO
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## v0.0.2
+
+### 🚀 Added
+
+* No additions today.
+
+### 🩹 Fixes
+
+* Replaced how we reference files from `rootpath` to the function for
+  `DataStorage:getDataDir` - I suspect this was causing some of the issues on
+  non-kobo devices (ie, worked on kobo does not mean it works everywhere)
+  
+* Removed a block from the original release that was causing the list of files
+  to be considered part of AirPlane Mode to include anything already disabled
+  - which also meant when exiting AirPlane Mode, it was erasing those entries
+  from the settings files
+
+* Removed a block that was setting a variable, replacing the value, resetting it, but never actually *using* it
+
+
+
+
 ## v0.0.1
 
 ### 🚀 Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 
 * Fixed how the wifi settings are re-enabled when exiting
 
+* Restore wifi state to the same state it was when AirPlane started - off or on
+
+* Fixed deleting all temporary plugin disables before restoring
+
 ## v0.0.2  (2025.05.22)
 
 ### 🚀 Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,17 @@
 
 ### TODO
 
-* action toggles are still not behaving
-
-* verify we aren't clobbering user settings for the plugins we turn off in our default init
-
 ### 🚀 Added
 
-* No additions today.
+* Gesture support
 
 ### 🩹 Fixes
 
 * Finally figured out enable/disble wifi so it works on different devices correctly. Tested on Clara and Kindle, plugin settings reverted correctly, wifi reconnected correctly, and wireless settings are not lost
 
 * Changed how we set and reset the disabled plugins list in the main settings.reader.lua. We were not always re-enabling plugins if they appeared in our own airplane module list.
+
+* Fixed how the wifi settings are re-enabled when exiting
 
 ## v0.0.2  (2025.05.22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v0.0.3  (2025.05.??) - UNRELEASED CURRENTLY
+
+### TODO
+
+* action toggles are still not behaving
+
+* verify we aren't clobbering user settings for the plugins we turn off in our default init
+
+### 🚀 Added
+
+* No additions today.
+
+### 🩹 Fixes
+
+* Finally figured out enable/disble wifi so it works on different devices correctly. Tested on Clara and Kindle, plugin settings reverted correctly, wifi reconnected correctly, and wireless settings are not lost
+
 ## v0.0.2  (2025.05.22)
 
 ### 🚀 Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.0.2
+## v0.0.2  (2025.05.22)
 
 ### 🚀 Added
 
@@ -19,10 +19,7 @@
 
 * Removed a block that was setting a variable, replacing the value, resetting it, but never actually *using* it
 
-
-
-
-## v0.0.1
+## v0.0.1 (2025.05.21)
 
 ### 🚀 Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 * Finally figured out enable/disble wifi so it works on different devices correctly. Tested on Clara and Kindle, plugin settings reverted correctly, wifi reconnected correctly, and wireless settings are not lost
 
+* Changed how we set and reset the disabled plugins list in the main settings.reader.lua. We were not always re-enabling plugins if they appeared in our own airplane module list.
+
 ## v0.0.2  (2025.05.22)
 
 ### 🚀 Added

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ For this iteration, I changed how we manage the plugins to disable/enable when s
 ## Installation
 
 1. Connect your device to USB
-1. Copy the `airplanemode.koplugin` directory to `.adds/koreader/plugins/` or unpack a release file in your plugins directory
+1. Copy the `airplanemode.koplugin` directory to `plugins/` or unpack a release file in your plugins directory. On Kobo, this would be in `.adds/koreader/plugins`, on kindle's it is usually in `/mnt/us/koreader/plugins` (if you use a different architecture, let me know and I'll add it :) 
 1. Disconnect USB
 
 ## Known bugs
 
-The only known bug is I've had a report from Kindle users that the module deactivating isn't working. I can duplicate this behavior in the koreader emulator and will tackle it next, but wanted to get this release out first since it is a significant change in functionality as far as plugin management.
+None reported (yet).
 
 ## Usage
 
@@ -28,7 +28,7 @@ In the Nework tab, tap or click the menu for `AirPlane Mode`.
 
 ![Screenshot of the Network tab with AirPlane Mode installed](<https://raw.githubusercontent.com/kodermike/kodermike.github.io/refs/heads/master/images/airplane_network_menu.png>)
 
-The `AirPlane Mode` menu is very simple - toggle `AirPlane Mode` and control which plugins will be disabled while it's running.
+The `AirPlane Mode` menu is very simple - you can toggle `AirPlane Mode` and control which plugins will be disabled while it's running.
 
 ![Screenshot of the AirPlane Mode menu when disabled](<https://raw.githubusercontent.com/kodermike/kodermike.github.io/refs/heads/master/images/airplane_disabled.png>)
 
@@ -38,7 +38,7 @@ Tapping on `Enable` will start `AirPlane Mode` and prompt to restart your device
 
 ### Disabliing
 
-Turning AirPlane Mode off is simple. Return to the `AirPlane Menu` in `Network` and tap the Disable the button. We will need to restart again since we are re-enabling plugins that were disabled while offline.
+Turning AirPlane Mode off is simple. Return to the `AirPlane Menu` in `Network` and tap the `Disable` the button. We will need to restart again since we are re-enabling plugins that were disabled while offline.
 
 ![Screenshot of the AirPlane Mode menu when disabled](<https://raw.githubusercontent.com/kodermike/kodermike.github.io/refs/heads/master/images/airplane_stopping.png>)
 
@@ -73,4 +73,4 @@ When you exit `AirPlane Mode`, any plugins that were not disabled before you sta
 
 Please open an issue in GitHub so we can start looking at what isn't working right.
 
-###### Updated 2025.05.21
+###### Updated 2025.05.22

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This plugin is intended to give you the ability to quickly put your koreader int
 
 ---
 
-## IF YOU TESTED THE ALPHA
+## IF YOU TESTED THE FIRST ALPHA
 
 For this iteration, I changed how we manage the plugins to disable/enable when switching modes. If your device is currently in `AirPlane Mode`, please exit `AirPlane Mode` before upgrading.
 
@@ -15,10 +15,6 @@ For this iteration, I changed how we manage the plugins to disable/enable when s
 1. Connect your device to USB
 1. Copy the `airplanemode.koplugin` directory to `plugins/` or unpack a release file in your plugins directory. On Kobo, this would be in `.adds/koreader/plugins`, on kindle's it is usually in `/mnt/us/koreader/plugins` (if you use a different architecture, let me know and I'll add it :) 
 1. Disconnect USB
-
-## Known bugs
-
-None reported (yet).
 
 ## Usage
 
@@ -73,4 +69,4 @@ When you exit `AirPlane Mode`, any plugins that were not disabled before you sta
 
 Please open an issue in GitHub so we can start looking at what isn't working right.
 
-###### Updated 2025.05.22
+###### Updated 2025.05.23

--- a/main.lua
+++ b/main.lua
@@ -112,8 +112,8 @@ function AirPlaneMode:turnon()
         G_reader_settings:saveSetting("wifi_disable_action","turn_off")
         G_reader_settings:flush()
 
-        if Device:hasWifiManager() then
-                NetworkMgr:disableWifi()
+        if NetworkMgr:isWifiOn() then
+            NetworkMgr:disableWifi(nil, true)
         end
 
         if Device:canRestart() then
@@ -163,15 +163,15 @@ function AirPlaneMode:turnoff()
     end
 
     if BK_Settings:has("wifi_enable_action") then
-        local wifi_enable_action = BK_Settings:readSetting("wifi_enable_action")
-        G_reader_settings:saveSetting("wifi_enable_action",wifi_enable_action)
+        local old_wifi_enable_action = BK_Settings:readSetting("wifi_enable_action")
+        G_reader_settings:saveSetting("wifi_enable_action",old_wifi_enable_action)
     else
         G_reader_settings:delSetting("wifi_enable_action")
     end
 
     if BK_Settings:has("wifi_disable_action") then
-        local wifi_disable_action = BK_Settings:readSetting("wifi_disable_action")
-        G_reader_settings:saveSetting("wifi_disable_action",wifi_disable_action)
+        local old_wifi_disable_action = BK_Settings:readSetting("wifi_disable_action")
+        G_reader_settings:saveSetting("wifi_disable_action",old_wifi_disable_action)
     else
         G_reader_settings:delSetting("wifi_disable_action")
     end
@@ -180,6 +180,10 @@ function AirPlaneMode:turnoff()
         local old_http_proxy_enabled = BK_Settings:readSetting("http_proxy_enabled")
         -- flip the real config
         G_reader_settings:saveSetting("http_proxy_enabled",old_http_proxy_enabled)
+    end
+
+    if not NetworkMgr:isWifiOn() then
+        NetworkMgr:enableWifi(nil, true)
     end
 
     local airplane_plugins = LuaSettings:open(self.airplane_plugins_file)
@@ -204,9 +208,6 @@ function AirPlaneMode:turnoff()
         os.remove(settings_bk)
     end
 
-    if Device:hasWifiManager() then
-        NetworkMgr:enableWifi()
-    end
     settings_bk_exists = false
     if Device:canRestart() then
         UIManager:askForRestart(_("KOReader needs to restart to finish disabling plugins for AirPlane Mode."))

--- a/main.lua
+++ b/main.lua
@@ -14,9 +14,8 @@ local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
 local _ = require("gettext")
 
-local rootpath = lfs.currentdir()
-local settings_file = rootpath.."/settings.reader.lua"
-local settings_bk = rootpath.."/settings.reader.lua.airplane"
+local settings_file = DataStorage:getDataDir().."/settings.reader.lua"
+local settings_bk = DataStorage:getDataDir().."/settings.reader.lua.airplane"
 local settings_bk_exists = false
 
 -- establish the main settings file
@@ -43,7 +42,7 @@ end
 function AirPlaneMode:init()
     self:onDispatcherRegisterActions()
     self.ui.menu:registerToMainMenu(self)
-    self.airplane_plugins_file = rootpath.."/settings/airplane_plugins.lua"
+    self.airplane_plugins_file = DataStorage:getDataDir().."/settings/airplane_plugins.lua"
 end
 
 function AirPlaneMode:initSettingsFile()
@@ -209,11 +208,6 @@ function AirPlaneMode:turnoff()
         NetworkMgr:enableWifi()
     end
     settings_bk_exists = false
-    local airplanemode_active = false
-    if G_reader_settings:readSetting("airplanemode") then
-        airplanemode_active = G_reader_settings:readSetting("airplanemode")
-    end
-    airplanemode_active = false
     if Device:canRestart() then
         UIManager:askForRestart(_("KOReader needs to restart to finish disabling plugins for AirPlane Mode."))
     else
@@ -281,7 +275,6 @@ function AirPlaneMode:getSubMenuItems()
         element.enable = nil
         table.insert(os_all_plugins, element)
     end
-    airplane_plugins:saveSetting("disabled_plugins",check_plugins)
 
     table.sort(os_all_plugins, function(v1, v2) return v1.fullname < v2.fullname end)
 


### PR DESCRIPTION

### 🚀 Added

* Gesture support

### 🩹 Fixes

* Finally figured out enable/disble wifi so it works on different devices correctly. Tested on Clara and Kindle, plugin settings reverted correctly, wifi reconnected correctly, and wireless settings are not lost

* Changed how we set and reset the disabled plugins list in the main settings.reader.lua. We were not always re-enabling plugins if they appeared in our own airplane module list.

* Fixed how the wifi settings are re-enabled when exiting

* Restore wifi state to the same state it was when AirPlane started - off or on

* Fixed deleting all temporary plugin disables before restoring