### PR TITLE
issue #32 - crash when not in a document and enabling/disabling

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -312,7 +312,10 @@ function AirPlaneMode:Enable()
 
     G_reader_settings:flush()
 
-    self.ui:saveSettings()
+    -- Only attempt to save reading state if we are in the reader
+    if string.match(self.name, "reader") then
+      self.ui:saveSettings()
+    end
 
     if Device:canRestart() then
       if apm_settings:isTrue("restoreopt") then
@@ -402,7 +405,9 @@ function AirPlaneMode:Disable()
   end
 
   settings_bk_exists = false
-  self.ui:saveSettings()
+  if string.match(self.name, "reader") then
+    self.ui:saveSettings()
+  end
   if Device:canRestart() then
     if apm_settings:isTrue("restoreopt") then
       saveState(self.name)


### PR DESCRIPTION
- wrap the save reading position so it only saves if we are actually reading