### PR TITLE
Issue 98 - double popup when disabling from the KOReader plugin manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v1.9.3] 🔥
+
+- Issue #98 - double popup appearing when disabling the plugin from the KOReader plugin manager.
+  - Added check that AirPlaneMode is running before trying to run stop for stopPlugin
+  - Added boolean interactive, default true, to determine if we need to display the restart
+
 ## [v1.9.2] 🔥
 
 - Other issue identified in issue #77 - the old restore where you left off code assumed there were only two options - in the reader or in the filebrowser. But with the use of new plugins to override the filebrowser (simpleui, etc.) that is no longer the fallback if not in reader. Fixed.

--- a/_meta.lua
+++ b/_meta.lua
@@ -2,5 +2,5 @@ local _ = require("gettext")
 return {
   fullname = _("AirPlaneMode"),
   description = _([[Quickly enable/disable networking and selected plugins in one action.]]),
-  version = "1.9.2",
+  version = "1.9.3",
 }

--- a/main.lua
+++ b/main.lua
@@ -234,12 +234,16 @@ function AirPlaneMode:migratesettings()
     U:delFlightSetting("airplanemode_in_footer", settings.koreader)
   end
 end
+
 ---Hook for stopPlugin support
 ---@return nil
 function AirPlaneMode:stopPlugin()
   local funcname = debug.getinfo(1, "n").name
   logger.dbg(funcname, "stopPlugin called at ", os.time())
-  self:Disable()
+  if U:getFlightStatus() then
+    local interactive = false
+    self:Disable(interactive)
+  end
 end
 -- expose non-method API (some callers invoke stopPlugin() without a self)
 local _method_stopPlugin = AirPlaneMode.stopPlugin
@@ -371,8 +375,13 @@ function AirPlaneMode:Enable()
 end
 
 ---Disable AirPlaneMode
+---@param interactive? boolean
 ---@return nil
-function AirPlaneMode:Disable()
+function AirPlaneMode:Disable(interactive)
+  if type(interactive) ~= "boolean" then
+    interactive = true
+  end
+
   if settings.debug_is_on then
     local funcname = debug.getinfo(1, "n").name
     logger.dbg(funcname, "Disabling AirPlaneMode")
@@ -466,36 +475,38 @@ function AirPlaneMode:Disable()
     self.ui:saveSettings()
   end
   UIManager:unschedule(self.update_status_bars, self)
-  if Device:canRestart() then
-    if settings.debug_is_on then
-      local funcname = debug.getinfo(1, "n").name
-      logger.dbg(funcname, "device can restart, checking restart options and restarting")
-    end
-    if U:FlightIsTrue("restoreopt") then
+  if interactive then
+    if Device:canRestart() then
       if settings.debug_is_on then
         local funcname = debug.getinfo(1, "n").name
-        logger.dbg(funcname, "saving state name")
+        logger.dbg(funcname, "device can restart, checking restart options and restarting")
       end
-      saveState(self.name)
-    end
-    if U:FlightNilOrFalse("silentmode") then
-      UIManager:askForRestart(_("KOReader needs to restart to finish disabling plugins for AirPlaneMode."))
+      if U:FlightIsTrue("restoreopt") then
+        if settings.debug_is_on then
+          local funcname = debug.getinfo(1, "n").name
+          logger.dbg(funcname, "saving state name")
+        end
+        saveState(self.name)
+      end
+      if U:FlightNilOrFalse("silentmode") then
+        UIManager:askForRestart(_("KOReader needs to restart to finish disabling plugins for AirPlaneMode."))
+      else
+        UIManager:restartKOReader()
+      end
     else
-      UIManager:restartKOReader()
+      if settings.debug_is_on then
+        local funcname = debug.getinfo(1, "n").name
+        logger.dbg(funcname, "device cannot restart, showing confirm box")
+      end
+      UIManager:show(ConfirmBox:new({
+        dismissable = false,
+        text = _("You will need to restart KOReader to finish disabling AirPlaneMode."),
+        ok_text = _("OK"),
+        ok_callback = function()
+          UIManager:quit()
+        end,
+      }))
     end
-  else
-    if settings.debug_is_on then
-      local funcname = debug.getinfo(1, "n").name
-      logger.dbg(funcname, "device cannot restart, showing confirm box")
-    end
-    UIManager:show(ConfirmBox:new({
-      dismissable = false,
-      text = _("You will need to restart KOReader to finish disabling AirPlaneMode."),
-      ok_text = _("OK"),
-      ok_callback = function()
-        UIManager:quit()
-      end,
-    }))
   end
 end
 


### PR DESCRIPTION
Because I was reusing the same stop block for both regular use and the call from the main plugin manager, users would be presented with overlapping restart messages.
- Added check that AirPlaneMode is running before trying to run stop for stopPlugin
- Added boolean *interactive*, default true, to determine if we need to display the restart

Issue #98 